### PR TITLE
Module 'rcOAuth2ClientDep' removed.

### DIFF
--- a/samples/requirejs-module-without-config-module.html
+++ b/samples/requirejs-module-without-config-module.html
@@ -1,0 +1,28 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <title>Sample using solely RequireJS modules without module 'rcOAuth2ClientDep' - RC OAuth 2.0 Client</title>
+    <link type="text/css" rel="stylesheet" href="../src/rc.oauth2.loginbar.css" />
+    <script src="requirejs-2.1.16.js"></script>
+</head>
+<body>
+    <div id="rc-oauth2-loginbar"></div>
+</body>
+</html>
+<script>
+
+	require.config({
+        baseUrl: "../src"
+	});
+
+	// Configurations defined in module 'rcOAuth2ClientDep' should not be IMO a module
+	// Configurations should be passed only with init method calls
+	require(['rc.oauth2.client', 'rc.oauth2.loginbar'], function(client, loginbar) {
+	
+		/* Init calls */
+			// rcOAuth2Client.init(
+			// rcOAuth2LoginBar.init(
+		if(console && console.log) console.log("init");
+			
+	});
+</script>

--- a/src/rc.oauth2.loginbar.js
+++ b/src/rc.oauth2.loginbar.js
@@ -11,11 +11,8 @@
     //AMD support
     //
     if (typeof define === "function" && define.amd) {
-        define(["module", "rcOAuth2ClientDep"], function (module, rcOAuth2Client) {
+        define(["module"], function (module) {
             var instance = factory;
-            if (module.config().hasOwnProperty("settings")) {
-                instance.init(rcOAuth2Client, module.config().settings, module.config().debug);
-            }
             return instance;
         });
         //


### PR DESCRIPTION
Hi, 

Configurations defined in module 'rcOAuth2ClientDep' should not be IMO a module. I think that configurations should be passed only afterward with init method calls. 

To launch the test page, you just have to do the following steps:
1. python -m SimpleHTTPServer 8000
2. Open http://127.0.0.1:8000/samples/requirejs-module-without-config-module.html
